### PR TITLE
Fix  vesting tests and penalty function

### DIFF
--- a/contracts/vesting/VestedZeroNFT.sol
+++ b/contracts/vesting/VestedZeroNFT.sol
@@ -31,6 +31,10 @@ contract VestedZeroNFT is
     PausableUpgradeable,
     ERC721EnumerableUpgradeable
 {
+	uint256 public constant QUART = 25000; //  25%
+	uint256 public constant HALF = 65000; //  65%
+	uint256 public constant WHOLE = 100000; // 100%
+
     IERC20 public zero;
     uint256 public lastTokenId;
     uint256 public denominator;
@@ -203,11 +207,13 @@ contract VestedZeroNFT is
     }
 
     /// @inheritdoc IVestedZeroNFT
-    function penalty(uint256 tokenId) public view returns (uint256) {
+    function penalty(uint256 tokenId) public view returns (uint256 penaltyAmount) {
         LockDetails memory lock = tokenIdToLockDetails[tokenId];
-        // (, uint256 _pending) = claimable(id);
-        // TODO
-        return (lock.pending * 5) / 10;
+
+        if (lock.unlockDate >= block.timestamp) {
+			uint256 penaltyFactor = ((lock.unlockDate - block.timestamp) * HALF) / lock.linearDuration + QUART;
+			penaltyAmount = (lock.pending * penaltyFactor) / WHOLE;
+		}
     }
 
     /// @inheritdoc IVestedZeroNFT

--- a/contracts/vesting/VestedZeroNFT.sol
+++ b/contracts/vesting/VestedZeroNFT.sol
@@ -14,7 +14,11 @@ pragma solidity ^0.8.20;
 
 import {IVestedZeroNFT} from "../interfaces/IVestedZeroNFT.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {IERC165, ERC721Upgradeable, ERC721EnumerableUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {
+    IERC165, 
+    ERC721Upgradeable,
+    ERC721EnumerableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
@@ -23,7 +27,8 @@ import {AccessControlEnumerableUpgradeable} from "@openzeppelin/contracts-upgrad
 
 /// @title VestedZeroNFT is a NFT based contract to hold all the user vests
 /// @author Deadshot Ryker <ryker@zerolend.xyz>
-/// @notice NFTs can be traded on secondary marketplaces like Opensea, can be split into smaller chunks to allow for smaller otc deals to happen in secondary markets
+/// @notice NFTs can be traded on secondary marketplaces like Opensea, can be split into smaller chunks 
+/// to allow for smaller otc deals to happen in secondary markets
 contract VestedZeroNFT is
     IVestedZeroNFT,
     AccessControlEnumerableUpgradeable,
@@ -130,101 +135,6 @@ contract VestedZeroNFT is
         }
     }
 
-    /// How much ZERO tokens this vesting nft can claim
-    /// @param _tokenId the id of the nft contract
-    /// @return upfront how much tokens upfront this nft can claim
-    /// @return pending how much tokens in the linear vesting (after the cliff) this nft can claim
-    function claimable(
-        uint256 _tokenId
-    ) public view returns (uint256 upfront, uint256 pending) {
-        LockDetails memory lock = tokenIdToLockDetails[_tokenId];
-        if (block.timestamp < lock.unlockDate) return (0, 0);
-
-        // if after the unlock date and before the cliff
-        if (
-            block.timestamp >= lock.unlockDate &&
-            block.timestamp < lock.unlockDate + lock.cliffDuration
-        ) return (lock.upfront, 0);
-
-        if (
-            block.timestamp >=
-            lock.unlockDate + lock.cliffDuration + lock.linearDuration
-        ) return (lock.upfront, lock.pending);
-
-        uint256 pct = ((block.timestamp -
-            (lock.unlockDate + lock.cliffDuration)) * denominator) /
-            lock.linearDuration;
-
-        return (lock.upfront, ((lock.pending * pct) / denominator));
-    }
-
-    /// @inheritdoc IVestedZeroNFT
-    function claim(
-        uint256 id
-    ) public nonReentrant whenNotPaused returns (uint256 toClaim) {
-        require(!frozen[id], "frozen");
-
-        LockDetails memory lock = tokenIdToLockDetails[id];
-
-        if (lock.hasPenalty) {
-            // if the user hasn't claimed before, then calculate how much penalty should be charged
-            // and send the remaining tokens to the user
-            if (lock.pendingClaimed == 0) {
-                uint256 _penalty = penalty(id);
-                toClaim += lock.pending - _penalty;
-                lock.pendingClaimed = lock.pending;
-
-                // send the penalty tokens back to the staking bonus
-                // contract (used for staking bonuses)
-                zero.transfer(stakingBonus, _penalty);
-            }
-        } else {
-            (uint256 _upfront, uint256 _pending) = claimable(id);
-
-            // handle vesting without penalties
-            // handle the upfront vesting
-            if (_upfront > 0 && lock.upfrontClaimed == 0) {
-                toClaim += _upfront;
-                lock.upfrontClaimed = _upfront;
-            }
-
-            // handle the linear vesting
-            if (_pending > 0 && lock.pendingClaimed >= 0) {
-                toClaim += _pending - lock.pendingClaimed;
-                lock.pendingClaimed += _pending - lock.pendingClaimed;
-            }
-        }
-
-        tokenIdToLockDetails[id] = lock;
-
-        if (toClaim > 0) zero.transfer(ownerOf(id), toClaim);
-    }
-
-    /// @inheritdoc IVestedZeroNFT
-    function claimed(uint256 tokenId) public view returns (uint256) {
-        LockDetails memory lock = tokenIdToLockDetails[tokenId];
-        return lock.upfrontClaimed + lock.pendingClaimed;
-    }
-
-    /// @inheritdoc IVestedZeroNFT
-    function penalty(uint256 tokenId) public view returns (uint256 penaltyAmount) {
-        LockDetails memory lock = tokenIdToLockDetails[tokenId];
-
-        if (lock.unlockDate >= block.timestamp) {
-			uint256 penaltyFactor = ((lock.unlockDate - block.timestamp) * HALF) / lock.linearDuration + QUART;
-			penaltyAmount = (lock.pending * penaltyFactor) / WHOLE;
-		}
-    }
-
-    /// @inheritdoc IVestedZeroNFT
-    function unclaimed(uint256 tokenId) public view override returns (uint256) {
-        LockDetails memory lock = tokenIdToLockDetails[tokenId];
-        return
-            lock.upfront +
-            lock.pending -
-            (lock.upfrontClaimed + lock.pendingClaimed);
-    }
-
     function claimUnvested(uint256 tokenId) external {
         require(msg.sender == stakingBonus, "!stakingBonus");
         uint256 _pending = unclaimed(tokenId);
@@ -275,6 +185,99 @@ contract VestedZeroNFT is
             hasPenalty: lock.hasPenalty,
             category: lock.category
         });
+    }
+
+    /// @inheritdoc IVestedZeroNFT
+    function claim(
+        uint256 id
+    ) public nonReentrant whenNotPaused returns (uint256 toClaim) {
+        require(!frozen[id], "frozen");
+
+        LockDetails memory lock = tokenIdToLockDetails[id];
+
+        if (lock.hasPenalty) {
+            // if the user hasn't claimed before, then calculate how much penalty should be charged
+            // and send the remaining tokens to the user
+            if (lock.pendingClaimed == 0) {
+                uint256 _penalty = penalty(id);
+                toClaim += lock.pending - _penalty;
+                lock.pendingClaimed = lock.pending;
+
+                // send the penalty tokens back to the staking bonus
+                // contract (used for staking bonuses)
+                zero.transfer(stakingBonus, _penalty);
+            }
+        } else {
+            (uint256 _upfront, uint256 _pending) = claimable(id);
+
+            // handle vesting without penalties
+            // handle the upfront vesting
+            if (_upfront > 0 && lock.upfrontClaimed == 0) {
+                toClaim += _upfront;
+                lock.upfrontClaimed = _upfront;
+            }
+
+            // handle the linear vesting
+            if (_pending > 0 && lock.pendingClaimed >= 0) {
+                toClaim += _pending - lock.pendingClaimed;
+                lock.pendingClaimed += _pending - lock.pendingClaimed;
+            }
+        }
+
+        tokenIdToLockDetails[id] = lock;
+
+        if (toClaim > 0) zero.transfer(ownerOf(id), toClaim);
+    }
+
+    /// How much ZERO tokens this vesting nft can claim
+    /// @param _tokenId the id of the nft contract
+    /// @return upfront how much tokens upfront this nft can claim
+    /// @return pending how much tokens in the linear vesting (after the cliff) this nft can claim
+    function claimable(
+        uint256 _tokenId
+    ) public view returns (uint256 upfront, uint256 pending) {
+        LockDetails memory lock = tokenIdToLockDetails[_tokenId];
+        if (block.timestamp < lock.unlockDate) return (0, 0);
+
+        // if after the unlock date and before the cliff
+        if (
+            block.timestamp >= lock.unlockDate &&
+            block.timestamp < lock.unlockDate + lock.cliffDuration
+        ) return (lock.upfront, 0);
+
+        if (
+            block.timestamp >=
+            lock.unlockDate + lock.cliffDuration + lock.linearDuration
+        ) return (lock.upfront, lock.pending);
+
+        uint256 pct = ((block.timestamp -
+            (lock.unlockDate + lock.cliffDuration)) * denominator) /
+            lock.linearDuration;
+
+        return (lock.upfront, ((lock.pending * pct) / denominator));
+    }
+
+    /// @inheritdoc IVestedZeroNFT
+    function claimed(uint256 tokenId) public view returns (uint256) {
+        LockDetails memory lock = tokenIdToLockDetails[tokenId];
+        return lock.upfrontClaimed + lock.pendingClaimed;
+    }
+
+    /// @inheritdoc IVestedZeroNFT
+    function penalty(uint256 tokenId) public view returns (uint256) {
+        LockDetails memory lock = tokenIdToLockDetails[tokenId];
+        // (, uint256 _pending) = claimable(id);
+        // TODO
+        return (lock.pending * 5) / 10;
+    }
+
+    /// @inheritdoc IVestedZeroNFT
+    function unclaimed(uint256 tokenId) public view override returns (uint256) {
+        LockDetails memory lock = tokenIdToLockDetails[tokenId];
+        return
+            lock.upfront +
+            lock.pending -
+            (lock.upfrontClaimed + lock.pendingClaimed);
     }
 
     /// @inheritdoc IVestedZeroNFT

--- a/test/fixtures/utils.ts
+++ b/test/fixtures/utils.ts
@@ -1,3 +1,15 @@
+import { impersonateAccount, setBalance } from "@nomicfoundation/hardhat-network-helpers";
+import { NumberLike } from "@nomicfoundation/hardhat-network-helpers/dist/src/types";
+import { ethers } from "hardhat";
+
 export const e18 = BigInt(10) ** 18n;
 export const supply = (100000000000n * e18) / 100n;
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const initMainnetUser = async (user: string, balance?: NumberLike) => {
+    await impersonateAccount(user);
+    if (balance !== undefined) {
+      await setBalance(user, balance);
+    }
+    return ethers.getSigner(user);
+};


### PR DESCRIPTION
This PR brings in the following

- New functionality for the penalty amount calculation based on time remaining to reach the unlock time
    - Calculation of Penalty:
The penalty is calculated by multiplying the earning by "PenaltyFactor".
If the unlockTime of the earning is greater than the current block timestamp (i.e., the earning is still locked), the function calculates a penalty factor.
The penalty factor starts decreases linearly (from 90% - 25%) based on the time remaining until the unlock time.
The penalty factor calculation formula is:

        > penaltyFactor = ((earning.unlockTime - block.timestamp) * HALF) / vestDuration + QUART

         where HALF represents 65%(this is a value from the contract), vestDuration is a parameter determining the duration over which penalties decay, and QUART represents 25%.
- New tests are added for Penalty Calculation, Split functionality, batch updation of tokens, royalty calculation etc. 

Find below the test coverage report 
![Screenshot 2024-03-28 at 12 40 09](https://github.com/zerolend/governance/assets/164490987/02c8a446-245b-4a27-83a9-42be21af4307)
