### PR TITLE
Update Airdrop Vesting Schedule to 6-Month Cliff with 1-Month Linear Vesting

### DIFF
--- a/scripts/updateCliff.ts
+++ b/scripts/updateCliff.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { VestedZeroNFT } from "../types";
 
 const VESTED_ZERO_NFT_ADDRESS = "0x9FA72ea96591e486FF065E7C8A89282dEDfA6C12";
-const LINEAR_DURATION = 86400 * 91;
+const LINEAR_DURATION = 86400 * 31;
 const CLIFF_DURATION = 86400 * 90;
 const tokenIds: number[] = [];
 


### PR DESCRIPTION
This PR modifies the vesting schedule for airdrop vests by updating the vesting period from a 6-month cliff and 3-month linear vesting to a 6-month cliff with a 1-month linear vesting. The script iterates through all existing vest IDs, checks for eligible airdrop vests, and updates them accordingly. Key updates include:

- Adjusted LINEAR_DURATION to 1 month (86400 * 31 seconds).
- Script filters for vests in the airdrop category (category 3) with a cliff duration greater than 90 days, as these are eligible for updating.
- Calls updateCliffDuration on the eligible vest IDs to apply the new cliff and linear duration parameters.